### PR TITLE
Reduce size of /usr/lib/locale/locale-archive by excluding a lot of locales

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1385,6 +1385,9 @@ glibc.chroot: kernel_headers.chroot
 	$(SED) '/test-installation/s@$$(PERL)@echo not running@' -i \
 	$(tgt_src_dir)/Makefile
 	$(MAKE) --directory=$(chroot_build)/glibc-build install
+	$(ECHO) "Overwriting locales with minimum set"
+	$(CP) $(chroot_build)/misc/glibc.SUPPORTED.locales \
+	$(tgt_src_dir)/localedata/SUPPORTED
 	$(MAKE) --directory=$(chroot_build)/glibc-build \
 	localedata/install-locales
 	$(CP) -f /tools/bin/{ld,ld-old}

--- a/misc/glibc.SUPPORTED.locales
+++ b/misc/glibc.SUPPORTED.locales
@@ -1,0 +1,28 @@
+# This file names the currently supported and somewhat tested locales.
+# If you have any additions please file a glibc bug report.
+SUPPORTED-LOCALES=\
+cs_CZ.UTF-8/UTF-8 \
+de_DE.UTF-8/UTF-8 \
+de_DE/ISO-8859-1 \
+de_DE@euro/ISO-8859-15 \
+el_GR/ISO-8859-7 \
+en_GB.UTF-8/UTF-8 \
+en_GB/ISO-8859-1 \
+en_HK/ISO-8859-1 \
+en_PH/ISO-8859-1 \
+en_US.UTF-8/UTF-8 \
+en_US/ISO-8859-1 \
+es_MX/ISO-8859-1 \
+fa_IR/UTF-8 \
+fr_FR.UTF-8/UTF-8 \
+fr_FR/ISO-8859-1 \
+fr_FR@euro/ISO-8859-15 \
+it_IT.UTF-8/UTF-8 \
+it_IT/ISO-8859-1 \
+ja_JP.EUC-JP/EUC-JP \
+ja_JP.UTF-8/UTF-8 \
+ru_RU.KOI8-R/KOI8-R \
+ru_RU.UTF-8/UTF-8 \
+tr_TR.UTF-8/UTF-8 \
+zh_CN.GB18030/GB18030 \
+zh_HK/BIG5-HKSCS \


### PR DESCRIPTION
Overwrite $(chroot_build)/misc/glibc.SUPPORTED.locales with a minimized list of locales during the glibc.chroot build process.