### PR TITLE
Add ssh-copy-id to ESOS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2165,6 +2165,7 @@ openssh.chroot: glibc.chroot zlib.chroot openssl.chroot
 	--without-openssl-header-check
 	$(MAKE) --directory=$(tgt_src_dir)
 	$(MAKE) --directory=$(tgt_src_dir) DESTDIR=/ install
+	$(INSTALL) -m755 $(tgt_src_dir)/contrib/ssh-copy-id /usr/bin
 	$(SED) -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' \
 	/etc/ssh/sshd_config
 	$(TOUCH) $(@)


### PR DESCRIPTION
ssh-copy-id is only 10KB.