### PR TITLE
Disable libblk's cache used e.g. by blkid, wipefs

### DIFF
--- a/etc/blkid.conf
+++ b/etc/blkid.conf
@@ -1,0 +1,1 @@
+CACHE_FILE=/dev/null


### PR DESCRIPTION
libblk uses a cache file
we want to make sure that wipefs always uses the physical layout instead.

/run/blkid/blkid.tab doesn't get generated anymore:

```
[root@node-245384-2 ~]# cat /etc/blkid.conf 
CACHE_FILE=/dev/null
[root@node-245384-2 ~]# blkid 
/dev/vdb1: LABEL_FATBOOT="ESOS_BOOT" LABEL="ESOS_BOOT" UUID="5420-8C0F" TYPE="vfat"
/dev/vdb2: LABEL="esos_root" UUID="76013f67-96f3-4669-aa9a-1e5e82c0e9e5" TYPE="ext2"
/dev/vdb3: LABEL="esos_conf" UUID="dc18ce01-79c4-4f13-8df8-8a53d03a4084" TYPE="ext2"
/dev/vdb4: LABEL="esos_logs" UUID="525f75fa-1134-4fdb-bc5a-d65333df9ff3" TYPE="ext2"
/dev/sda: PTTYPE="atari"
[root@node-245384-2 ~]# wipefs /dev/vdb
DEVICE OFFSET TYPE UUID LABEL
vdb    0x1fe  dos       
[root@node-245384-2 ~]# wipefs /dev/vdb1
DEVICE OFFSET TYPE UUID      LABEL
vdb1   0x52   vfat 5420-8C0F ESOS_BOOT
vdb1   0x0    vfat 5420-8C0F ESOS_BOOT
vdb1   0x1fe  vfat 5420-8C0F ESOS_BOOT
[root@node-245384-2 ~]# ls -l /run/blkid/blkid.tab
ls: /run/blkid/blkid.tab: No such file or directory
[root@node-245384-2 ~]# 
```