### PR TITLE
no RAM size check with esos_persist option

### DIFF
--- a/misc/initramfs_init
+++ b/misc/initramfs_init
@@ -84,10 +84,12 @@ if [ -e /proc/vmcore ]; then
 	reboot -f || rescue_shell
 fi
 
-# Make sure we have enough physical memory
-if [ `cat /proc/meminfo | grep MemTotal | awk '{print $2}'` -lt 3500000 ]; then
-	echo "ESOS requires at least 3.5 GB of usable RAM!"
-	rescue_shell
+# Make sure we have enough physical memory if the system is running from RAM (default)
+if ! grep esos_persist /proc/cmdline > /dev/null 2>&1; then
+	if [ `cat /proc/meminfo | grep MemTotal | awk '{print $2}'` -lt 3500000 ]; then
+		echo "ESOS requires at least 3.5 GB of usable RAM!"
+		rescue_shell
+	fi
 fi
 
 # Get the slot kernel parameter


### PR DESCRIPTION
Disable the RAM size check if esos_persist kernel commandline option is used.
Enforcing this ram amount is relevant only if ESOS needs to run from RAM.
If ESOS is run with esos_persist kernel parameter, it is not doing that.

With this change, people that want to use ESOS with less than 3GB of RAM
only need to edit the grub config in their boot partition to add esos_persist
and they are set, no need to recompile/rebuild initramfs.