### PR TITLE
Updating a few python3 packages to avoid unwanted pip downloading

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2418,13 +2418,13 @@ Python.chroot: glibc.chroot gcc.chroot bzip2.chroot readline.chroot \
 	pip3 install cmd2==2.2.0
 	pip3 install xmltodict==0.12.0
 	pip3 install aiohttp==3.8.3
-	pip3 install frozenlist==1.1.1
+	pip3 install frozenlist==1.3.3
 	pip3 install charset-normalizer==2.1.1
-	pip3 install yarl==1.8.2
+	pip3 install yarl==1.9.1
 	pip3 install async-timeout==4.0.2
 	pip3 install multidict==6.0.4
-	pip3 install aiosignal==1.1.2
-	pip3 install idna==2.0
+	pip3 install aiosignal==1.3.1
+	pip3 install idna==2.10
 	pip3 install typing-extensions==4.5.0
 	pip3 install async-lru==2.0.2
 	pip3 install caio==0.9.11


### PR DESCRIPTION
The python3 build section was downloading some packages twice-- once at the specified version, and then again at the most recent version-- to satisfy overall requirements.  Updated these package versions.